### PR TITLE
fix: remove the `https://` prefix in the reset link

### DIFF
--- a/src/services/auth_service.py
+++ b/src/services/auth_service.py
@@ -234,7 +234,7 @@ class AuthService:
                 send_email,
                 user_email,
                 context=ForgotPasswordContext(
-                    reset_link=f"https://{settings.FRONTEND_URL}/reset_link?token={token}"
+                    reset_link=f"{settings.FRONTEND_URL}/reset_link?token={token}"
                 ),
             )
         response = {

--- a/templates/forgot_password.html
+++ b/templates/forgot_password.html
@@ -52,9 +52,13 @@
 
         <p>Click the link below to reset your password:</p>
 
-        <div class="reset-link">
-            {{ reset_link }}
-        </div>
+        <a href="{{ reset_link }}"
+           style="display: inline-block; padding: 10px 20px;
+                  background-color: #007BFF; color: white;
+                  text-decoration: none; border-radius: 6px;
+                  font-family: Arial, sans-serif; font-size: 16px;">
+            Reset Password
+        </a>
 
         <p>This link will expire in 10 minutes.</p>
 


### PR DESCRIPTION
- change the password reset link to a button in html